### PR TITLE
Remove dependency on spectral

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,11 @@ repository = "https://github.com/paulchernoch/hilbert"
 
 [dependencies]
 num = "0.4"
-spectral = "0.6.0"
-criterion = "0.3"
 rand = "0.8"
 quantogram = "0.4.3"
+
+[dev-dependencies]
+criterion = "0.3"
 
 [[bench]]
 name = "transform_benchmarks"

--- a/src/interleaver.rs
+++ b/src/interleaver.rs
@@ -82,7 +82,6 @@ impl Interleaver {
 #[cfg(test)]
 mod tests {
     #[allow(unused_imports)]
-    use spectral::prelude::*;
     use crate::transform::fast_hilbert;
     use crate::interleaver::Interleaver;
 
@@ -97,7 +96,7 @@ mod tests {
         let interleaver = Interleaver::new(dimensions, bit_depth);
         let actual = fast_hilbert::interleave_be(&axes, 5, Some(&interleaver));
         let expected : Vec<u8> = vec![100,76];
-        asserting("Correct interleave result using Interleaver").that(&actual).is_equal_to(expected);
+        assert_eq!(&actual, &expected, "Correct interleave result using Interleaver");
     }
 
 }

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -237,7 +237,6 @@ impl FloatDataRange {
 mod tests {
 
     #[allow(unused_imports)]
-    use spectral::prelude::*;
     use super::{IntegerDataRange, FloatDataRange};
 
     #[test]
@@ -245,7 +244,7 @@ mod tests {
         let points = test_points_i32();
         let actual_range = IntegerDataRange::from_i32(&points);
         let expected_range = IntegerDataRange::new(-100, 100);
-        asserting("Range correct").that(&actual_range).is_equal_to(expected_range);
+        assert_eq!(&actual_range, &expected_range, "Range correct");
     }
 
     #[test]
@@ -254,7 +253,7 @@ mod tests {
         let range = IntegerDataRange::from_i32(&points);
         let actual_normalized = range.normalize(-16);
         let expected_normalized = 84;
-        asserting("Normalized value correct").that(&actual_normalized).is_equal_to(expected_normalized);
+        assert_eq!(actual_normalized, expected_normalized, "Normalized value correct");
     }    
 
     #[test]
@@ -263,7 +262,7 @@ mod tests {
         let range = IntegerDataRange::from_i32(&points);
         let actual_compressed = range.compress(-16, 7);
         let expected_compressed = 42;
-        asserting("Compressed value correct").that(&actual_compressed).is_equal_to(expected_compressed);
+        assert_eq!(actual_compressed, expected_compressed, "Compressed value correct");
     }
 
     #[test]
@@ -271,7 +270,7 @@ mod tests {
         let in_out_pairs = vec![(0_u64,0), (1,0), (2,1), (3,2), (4,2), (5,3), (6,3), (7,3), (8,3), (9,4)];
         for (n, expected) in in_out_pairs {
             let actual = super::smallest_power_of_two(n);
-            asserting(&format!("n = {}, actual = {}, expected = {}", n, actual, expected)).that(&actual).is_equal_to(expected);
+            assert_eq!(actual, expected, "n = {}, actual = {}, expected = {}", n, actual, expected);
         }
     }
 
@@ -280,7 +279,7 @@ mod tests {
         let points = test_points_f64();
         let actual_range = FloatDataRange::from_f64(&points, 10.0);
         let expected_range = FloatDataRange::new(-100.0, 100.19, 10.0);
-        asserting("Range correct").that(&actual_range).is_equal_to(expected_range);
+        assert_eq!(actual_range, expected_range, "Range correct");
     }
 
     #[test]
@@ -289,7 +288,7 @@ mod tests {
         let range = FloatDataRange::from_f64(&points, 10.0);
         let actual_normalized = range.normalize(-16.0);
         let expected_normalized = 840;
-        asserting("Normalized value correct").that(&actual_normalized).is_equal_to(expected_normalized);
+        assert_eq!(actual_normalized, expected_normalized, "Normalized value correct");
     }
 
     /// Compress a value in a range that requires 11 bits down to 7 bits, forcing a division by 16 and loss of precision. 
@@ -299,7 +298,7 @@ mod tests {
         let range = FloatDataRange::from_f64(&points, 10.0);
         let actual_compressed = range.compress(-16.0, 7);
         let expected_compressed = 52;
-        asserting("Compressed value correct").that(&actual_compressed).is_equal_to(expected_compressed);
+        assert_eq!(actual_compressed, expected_compressed, "Compressed value correct");
     }    
 
     fn test_points_i32() -> Vec<Vec<i32>> {

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -130,7 +130,6 @@ impl Permutation {
 /// Tests of the Permutation methods.
 mod tests {
     #[allow(unused_imports)]
-    use spectral::prelude::*;
     use crate::permutation::Permutation;
 
     #[test]
@@ -140,7 +139,7 @@ mod tests {
         let permutation = Permutation::new(&moves);
         let actual_permuted_data = permutation.apply(&data);
         let expected_permuted_data = vec![4,6,2,10,8];
-        asserting("Correct permutation").that(&actual_permuted_data).is_equal_to(expected_permuted_data);
+        assert_eq!(actual_permuted_data, expected_permuted_data, "Correct permutation");
     }
 
     #[test]
@@ -160,7 +159,7 @@ mod tests {
         let swapped = permutation.swap(2, 3); // -> [2,0,4,1,3]
         let actual_permuted_data = swapped.apply(&data);
         let expected_permuted_data = vec![4,8,2,10,6];
-        asserting("swapped permutation").that(&actual_permuted_data).is_equal_to(expected_permuted_data);
+        assert_eq!(actual_permuted_data, expected_permuted_data, "swapped permutation");
     }
 
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -253,7 +253,6 @@ impl PartialEq for Point {
 /// Tests of the Point methods.
 mod tests {
     #[allow(unused_imports)]
-    use spectral::prelude::*;
     extern crate rand;
     use rand::thread_rng;
     use rand::seq::SliceRandom;
@@ -264,7 +263,7 @@ mod tests {
     fn square_distance() {
         let p1 = Point::new(0, &[3, 4, 5]);
         let p2 = Point::new(0, &[0, 8, 10]);
-        asserting!("Square distance between points").that(&p1.square_distance(&p2)).is_equal_to(50);
+        assert_eq!(p1.square_distance(&p2), 50, "Square distance between points");
     }
 
     #[test]
@@ -275,11 +274,11 @@ mod tests {
 
         // After shuffling, the points should not be in the same order.
         actual_points.shuffle(&mut rng);
-        asserting("Points not sorted by Hilbert Index").that(&actual_points).is_not_equal_to(expected_points.clone());
+        assert_ne!(actual_points, expected_points.clone(), "Points not sorted by Hilbert Index");
 
         // After sorting, the points should once again be in teh same order.
         Point::hilbert_sort(&mut actual_points, 3);
-        asserting("Points sorted by Hilbert Index").that(&actual_points).is_equal_to(expected_points);
+        assert_eq!(actual_points, expected_points, "Points sorted by Hilbert Index");
     }
 
     #[test]
@@ -287,7 +286,7 @@ mod tests {
         let p1 = Point::new(0, &[3, 4, 5]);
         let index = p1.hilbert_transform(5);
         let p2 = Point::new_from_hilbert_index(0, &index, 5, 3);
-        asserting("Point to Hilbert round trip").that(&p1).is_equal_to(p2);
+        assert_eq!(p1, p2, "Point to Hilbert round trip");
     }
 
     /// Construct all sixty-four possible 2-dimensional Points, each with coordinates requiring no more than 3 bits to represent

--- a/src/point_list.rs
+++ b/src/point_list.rs
@@ -100,7 +100,6 @@ where
 mod tests {
 
     #[allow(unused_imports)]
-    use spectral::prelude::*;
     use crate::point::Point;
 
     /// Make some points and verify that they are properly normalized and the required number of bits is properly identified.
@@ -108,7 +107,7 @@ mod tests {
     fn make_points_f64() {
         let float_points = test_points_f64();
         let (actual_points, bits_used) = super::make_points_f64(&float_points, 0, None, None, 10.0);
-        asserting("correct bits_used").that(&bits_used).is_equal_to(11);
+        assert_eq!(bits_used, 11, "correct bits_used");
         let expected_points = vec![
             Point::new(0, &vec![895, 1053, 1037]),
             Point::new(0, &vec![952, 1202, 2002]),
@@ -117,7 +116,7 @@ mod tests {
         for i in 0..3 {
             let expected_point = &expected_points[i];
             let actual_point = &actual_points[i];
-            asserting(&format!("For point {:?}", expected_point)).that(&expected_point.are_coordinates_identical(actual_point)).is_equal_to(true);
+            assert!(&expected_point.are_coordinates_identical(actual_point), "For point {:?}", expected_point);
         }
     }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -345,7 +345,6 @@ mod tests {
     use std::ops::Sub;
 
     #[allow(unused_imports)]
-    use spectral::prelude::*;
     use super::fast_hilbert;
 
    #[test]
@@ -353,8 +352,8 @@ mod tests {
         let big : BigUint = 329_u32.into(); // 329 = 256 + 64 + 8 + 1 = 0000101001001 (high to low) or 1001001010000 (low to high)
         let actual_bit_array = fast_hilbert::unpack_big_integer(&big, 12);
         let expected_bit_array : Vec<u8> = vec![1,0,0,1,0,0,1,0,1,0,0,0];
-        asserting!("Correct number of bits").that(&actual_bit_array.len()).is_equal_to(12);
-        asserting!("Correct ordering of bits").that(&actual_bit_array).is_equal_to(expected_bit_array);
+        assert_eq!(actual_bit_array.len(), 12, "Correct number of bits");
+        assert_eq!(actual_bit_array, expected_bit_array, "Correct ordering of bits");
     }
 
     #[test]
@@ -367,7 +366,7 @@ mod tests {
         let gray_code : BigUint = 25676_u32.into();
         let actual_axes = fast_hilbert::uninterleave(&gray_code, 5, 3, true);
         let expected_axes : Vec<u32> = vec![17, 24, 6];
-        asserting("Correct uninterleave result").that(&actual_axes).is_equal_to(expected_axes);
+        assert_eq!(actual_axes, expected_axes, "Correct uninterleave result");
     }
 
     #[test]
@@ -380,7 +379,7 @@ mod tests {
         let gray_code : BigUint = 8_u32.into();
         let actual_axes = fast_hilbert::uninterleave(&gray_code, 3, 2, true);
         let expected_axes : Vec<u32> = vec![2, 0];
-        asserting("Correct uninterleave result").that(&actual_axes).is_equal_to(expected_axes);
+        assert_eq!(actual_axes, expected_axes, "Correct uninterleave result");
     }
 
     #[test]
@@ -391,7 +390,7 @@ mod tests {
         let axes : Vec<u32> = vec![17, 24, 6];
         let actual = fast_hilbert::untranspose(&axes, 5, None);
         let expected : BigUint = 25676_u32.into();
-        asserting("Correct untranspose result").that(&actual).is_equal_to(expected);
+        assert_eq!(actual, expected, "Correct untranspose result");
     }
 
     #[test]
@@ -402,7 +401,7 @@ mod tests {
         let axes : Vec<u32> = vec![17, 24, 6];
         let actual = fast_hilbert::interleave_be(&axes, 5, None);
         let expected : Vec<u8> = vec![100,76];
-        asserting("Correct interleave result").that(&actual).is_equal_to(expected);
+        assert_eq!(actual, expected, "Correct interleave result");
     }
 
     fn abs_difference<T: Sub<Output = T> + Ord>(x: T, y: T) -> T {
@@ -466,7 +465,7 @@ mod tests {
             let coordinates = fast_hilbert::hilbert_axes(&expected_hilbert_index, bits, dimensions);
             let actual_hilbert_index = fast_hilbert::hilbert_index(&coordinates, bits, None);
 
-            asserting(&format!("Invertible for i = {}", i)).that(&actual_hilbert_index).is_equal_to(expected_hilbert_index);
+            assert_eq!(actual_hilbert_index, expected_hilbert_index, "Invertible for i = {}", i);
             previous = match previous {
                 None => Some((coordinates.clone(), None)),
                 Some((previous_coordinates, None)) => {
@@ -487,8 +486,7 @@ mod tests {
                     match verify_difference(&coordinates, &previous_coordinates) {
                         Ok(changed_dim) => {
                             if previous_changed_dim == changed_dim {
-                                asserting(&format!("Dimension {} changed more than thrice in a row at i = {}", previous_changed_dim, i))
-                                    .that(&same_dimension_changed_thrice).is_equal_to(false);
+                                assert_eq!(same_dimension_changed_thrice, false, "Dimension {} changed more than thrice in a row at i = {}", previous_changed_dim, i);
                                 if same_dimension_changed_twice {
                                     same_dimension_changed_thrice = true;
                                 }
@@ -503,7 +501,7 @@ mod tests {
                             Some((coordinates, Some(changed_dim)))
                         },
                         Err(msg) => {
-                            asserting(&format!("Error: {} for Hilbert index = {}", msg, i)).that(&true).is_equal_to(false);
+                            assert!(false, "Error: {} for Hilbert index = {}", msg, i);
                             panic!("Should never reach this line");
                         }
                     }
@@ -538,7 +536,7 @@ mod tests {
         for i in 0..num_points {
             let hilbert_index : BigUint = i.into();
             let coordinates = fast_hilbert::hilbert_axes(&hilbert_index, bits, dimensions);
-            asserting(&format!("Hilbert Index = {}. Expected {:?}. Actual {:?}", i, expected[i], coordinates)).that(&coordinates).is_equal_to(expected[i].clone());
+            assert_eq!(coordinates, expected[i].clone(), "Hilbert Index = {}. Expected {:?}. Actual {:?}", i, expected[i], coordinates);
         }
     }
 
@@ -550,7 +548,7 @@ mod tests {
         let hilbert_index : BigUint = index.into();
         let actual_point = fast_hilbert::hilbert_axes(&hilbert_index, bits, dimensions);
         let expected_point = vec![2,2];
-        asserting(&format!("Hilbert Index = {}. Expected {:?}. Actual {:?}", index, expected_point, actual_point)).that(&actual_point).is_equal_to(expected_point);
+        assert_eq!(actual_point, expected_point, "Hilbert Index = {}. Expected {:?}. Actual {:?}", index, expected_point, actual_point);
     }
 
     


### PR DESCRIPTION
Instead using normal asserts.
Spectral hasn't been updated in a long time, and depends on old version of num.

Also, moved the criterion dependency to dev-dependencies.